### PR TITLE
Remove Cerberus-specific code

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -20,16 +20,16 @@ repositories {
 
 dependencies {
     compile "org.apache.commons:commons-lang3:3.4"
-    compile "com.squareup.okhttp3:okhttp:3.3.1"
+    compile "com.squareup.okhttp3:okhttp:3.7.0"
     compile "com.google.code.gson:gson:2.5"
     compile "com.google.code.findbugs:jsr305:3.0.1"
-    compile "org.slf4j:slf4j-api:1.7.14"
+    compile "org.slf4j:slf4j-api:1.7.25"
 
     testCompile "junit:junit:4.12"
     testCompile "org.mockito:mockito-core:1.10.19"
     testCompile "org.powermock:powermock-api-mockito:1.6.4"
     testCompile "org.powermock:powermock-module-junit4:1.6.4"
     testCompile "org.assertj:assertj-core:2.3.0"
-    testCompile "com.squareup.okhttp3:mockwebserver:3.0.1"
+    testCompile "com.squareup.okhttp3:mockwebserver:3.7.0"
     testCompile "commons-io:commons-io:2.4"
 }

--- a/src/main/java/com/nike/vault/client/ClientVersion.java
+++ b/src/main/java/com/nike/vault/client/ClientVersion.java
@@ -33,11 +33,6 @@ public class ClientVersion {
 
     private static final String VAULT_CLIENT_VERSION_PROPERTY = "java_vault_client.version";
 
-    public static final String CERBERUS_CLIENT_HEADER = "X-Cerberus-Client";
-
-    protected static final String HEADER_VALUE_PREFIX = "JavaVaultClient/";
-
-
     public static String getVersion() {
 
         String clientVersion = "unknown";
@@ -52,9 +47,5 @@ public class ClientVersion {
         }
 
         return clientVersion;
-    }
-
-    public static String getClientHeaderValue() {
-        return HEADER_VALUE_PREFIX + getVersion();
     }
 }

--- a/src/main/java/com/nike/vault/client/VaultClient.java
+++ b/src/main/java/com/nike/vault/client/VaultClient.java
@@ -69,9 +69,6 @@ public class VaultClient {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
-    private final String javaVaultClientHeaderValue;
-
-
     /**
      * Explicit constructor that allows for full control over construction of the Vault client.
      *
@@ -97,7 +94,6 @@ public class VaultClient {
         this.urlResolver = vaultUrlResolver;
         this.credentialsProvider = credentialsProvider;
         this.httpClient = httpClient;
-        this.javaVaultClientHeaderValue = ClientVersion.getClientHeaderValue();
     }
 
 
@@ -270,8 +266,7 @@ public class VaultClient {
             Request.Builder requestBuilder = new Request.Builder()
                     .url(url)
                     .addHeader(HttpHeader.VAULT_TOKEN, credentialsProvider.getCredentials().getToken())
-                    .addHeader(HttpHeader.ACCEPT, DEFAULT_MEDIA_TYPE.toString())
-                    .addHeader(ClientVersion.CERBERUS_CLIENT_HEADER, javaVaultClientHeaderValue);
+                    .addHeader(HttpHeader.ACCEPT, DEFAULT_MEDIA_TYPE.toString());
 
             if (requestBody != null) {
                 requestBuilder.addHeader(HttpHeader.CONTENT_TYPE, DEFAULT_MEDIA_TYPE.toString())

--- a/src/test/java/com/nike/vault/client/ClientVersionTest.java
+++ b/src/test/java/com/nike/vault/client/ClientVersionTest.java
@@ -16,11 +16,9 @@
 
 package com.nike.vault.client;
 
-import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Tests ClientVersion class
@@ -35,12 +33,5 @@ public class ClientVersionTest {
     @Test
     public void test_that_version_is_not_null() {
         assertNotNull(ClientVersion.getVersion());
-    }
-
-    @Test
-    public void test_that_header_value_includes_right_prefix() {
-
-        String result = ClientVersion.getClientHeaderValue();
-        assertTrue(StringUtils.contains(result, ClientVersion.HEADER_VALUE_PREFIX));
     }
 }


### PR DESCRIPTION
The Vault client is for interacting with Vault, and is not specific to Cerberus, so removing Cerberus code.

Also, update old dependencies to latest version.